### PR TITLE
fix(bin): expose cli commitlint-codedependant

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Commitlint configuration for for enforcing codedependant commit styles",
   "main": "index.js",
+  "bin": {
+    "commitlint-codedependant": "bin/cli.js"
+  },
   "directories": {
     "lib": "lib",
     "bin": "bin"


### PR DESCRIPTION
This exposes the command line too and a bin script for usage globally
or from an npm run script