### PR TITLE
fix(bin): expose cli commitlint-codedependant

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,6 @@
   "bugs": {
     "url": "https://github.com/esatterwhite/commitlint-config-codedependant/issues"
   },
-  "release": {
-    "extends": "semantic-release-npm-github-publish",
-    "branches": [
-      "main"
-    ]
-  },
   "commitlint": {
     "extends": [
       "./index.js"
@@ -85,13 +79,14 @@
   },
   "homepage": "https://github.com/esatterwhite/commitlint-config-codedependant#readme",
   "devDependencies": {
+    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/git": "^9.0.0",
     "eslint": "^7.21.0",
     "eslint-config-codedependant": "^2.1.5",
     "execa": "^5.0.0",
     "glob": "^7.1.6",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.4.0",
-    "semantic-release-npm-github-publish": "^1.4.0",
     "tap": "^14.11.0"
   },
   "dependencies": {

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,49 @@
+'use strict'
+
+module.exports = {
+  branches: [
+    'main'
+  ]
+, npmPublish: true
+, plugins: [
+    ['@semantic-release/commit-analyzer', {
+      parserOpts: {
+        noteKeywords: ['BREAKING', 'BREAKING CHANGE', 'BREAKING CHANGES']
+      , referenceActions: [
+          'close', 'closes', 'closed'
+        , 'fix', 'fixes', 'fixed'
+        , 'resolve', 'resolves', 'resolved'
+        ]
+      }
+    , releaseRules: [
+        {breaking: true, release: 'major'}
+      , {revert: true, release: 'patch'}
+      , {type: 'build', release: 'patch'}
+      , {type: 'ci', release: 'patch'}
+      , {type: 'release', release: 'patch'}
+      , {type: 'chore', release: 'patch'}
+      , {type: 'refactor', release: 'patch'}
+      , {type: 'test', release: 'patch'}
+      , {type: 'doc', release: 'patch'}
+      , {type: 'lib', release: 'patch'}
+      ]
+    }],
+  , ['@semantic-release/release-notes-generator', null]
+  , ['@semantic-release/changelog', {
+      changelogTitle: '# Changlog'
+    , changelogFile: 'CHANGELOG.md'
+    }]
+  , ['@semantic-release/npm', {
+      tarballDir: 'dist',
+      assets: 'dist/*.tgz'
+    }]
+  , ['@semantic-release/git', {
+      assets: [
+        'package.json'
+      , 'package-lock.json'
+      , 'CHANGELOG.md'
+      ]
+    }]
+  , ['@semantic-release/github', null]
+  ]
+}


### PR DESCRIPTION
This exposes the command line too and a bin script for usage globally
or from an npm run script